### PR TITLE
Markdown Infostrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Our application is going to depend on a couple super helpful npm packages:
 
 To install these packages we'll type:
 
-```
+```shell
 npm install changes-stream request --save
 ```
 ... which will add both of our dependencies to our `package.json`.
@@ -86,7 +86,7 @@ The first thing we'll do inside our `index.js` is use the `changes-stream`
 package to create a new `ChangesStream` to listen to listen to the npm
 registry. To do so we'll write:
 
-```
+```javascript
 1  const ChangeStream = require('changes-stream');
 2 
 3  const db = 'https://replicate.npmjs.com';
@@ -106,7 +106,7 @@ Let's talk about what's happening here:
 Now that we've created a changes stream, let's listen to it! To do this, we
 write:
 
-```
+```javascript
 9  changes.on('data', function(change) {
 10   console.log(change);
 11 });
@@ -114,14 +114,14 @@ write:
 
 Let's test it out: Run this application by typing:
 
-```
+```shell
 node index.js
 ```
 
 If everything is working correctly, you'll see something like this start
 **streaming** through your console:
 
-```
+```javascript
 { seq: 445,
   id: 'CompoundSignal',
   changes: [ { rev: '5-a0695c30fdaa3471246ef0cd6c8a476d' } ] }
@@ -155,7 +155,7 @@ So our follower works! But it's not that great right now because we don't
 really have all that much interesting data. Let's look at what we have
 right now:
 
-```
+```javascript
 { seq: 446,
   id: 'amphibian',
   changes: [ { rev: '5-1a864e76d844e90bf6c63cb94303b593' } ] }
@@ -179,7 +179,7 @@ object we received from the stream.
 
 The two changes we make to our code look like this:
 
-```
+```javascript
 5  var changes = new ChangesStream({
 6    db: db,
 7    include_docs: true            // <- this is the thing we're adding
@@ -217,7 +217,7 @@ different pieces of data you can get from this stream. You may notice that
 some nested structures appear like `[Object]` in your console. You can
 print those out by adding `JSON.stringify` to your log, like this:
 
-```
+```javascript
 console.log(JSON.stringify (change.doc,null,' '));
 ```
 
@@ -250,7 +250,7 @@ https:/replicate.npmjs.com
 
 ...you should see something that looks like this:
 
-```
+```json
 {
   "db_name": "registry",
   "doc_count": 345391,
@@ -282,7 +282,7 @@ db up until the time we accessed the `update_seq` value.
 That was a lot of words, let's take a look at what this would look like in
 code.
 
-```
+```javascript
 2  const Request = require('request');
 ...
 11 Request.get(db, function(err, req, body) {        // <- make a request to the db
@@ -337,12 +337,12 @@ by checking if it has a `name`. We can accomplish this by checking if
 change.doc.name` has a value before we do anything with the `change` data. In our
 code, this looks like this:
 
-```
+```javascript
 ...
 17 if (change.doc.name) {             // <-- make sure the change is a change
 18   console.log(change.doc);
 19 }
-``` 
+```
 
 Ok, so we're **almost** done. Actually, we are totally done. But there's one last
 thing we can do to make our data even better: we can normalize our data so that
@@ -354,19 +354,19 @@ To do this, we'll add *one more* dependency to our application: [`normalize-regi
 
 First things first: let's install this package and save it to our `package.json`:
 
-```
+```shell
 npm install normalize-registry-metadata --save
 ```
 
 Next, we require in our `index.js`:
 
-```
+```javascript
 3  const Normalize = require(`normalize-registry-metadata`);
 ```
 
 Lastly, let's call `Normalize()` on the `change` data before we log it to the console:
 
-```
+```javascript
 ...
 18   console.log(Normalize(change.doc));        // <-- we only have to change this line!
 ...
@@ -429,7 +429,7 @@ Multiple buffers of 16 objects each, plus lingering data not yet
 picked up by the garbage collector, can eat your RAM lunch quick.
 To reduce this number:
 
-```
+```javascript
 new ChangesStream({
   db: 'https://replicate.npmjs.com',
   include_docs: true,


### PR DESCRIPTION
This small PR adds "infostrings"---those tags after the backticks of Markdown fenced code blocks---to get the code highlighted.

As it turns out, GitHub's highlighter works plenty fine with line numbering.
